### PR TITLE
Change 'Outdated' to 'Update' in ThemeRepo

### DIFF
--- a/Plugins/ThemeRepo/ThemeRepo.plugin.js
+++ b/Plugins/ThemeRepo/ThemeRepo.plugin.js
@@ -684,7 +684,7 @@ class ThemeRepo {
 			BDFDB.toggleClass(entry, "outdated", state == 1);
 			BDFDB.toggleClass(entry, "updated", state < 1);
 			let downloadbutton = entry.querySelector(".btn-download");
-			downloadbutton.innerText = state < 1 ? "Updated" : (state > 1 ? "Download" : "Outdated");
+			downloadbutton.innerText = state < 1 ? "Updated" : (state > 1 ? "Download" : "Update");
 			downloadbutton.style.setProperty("background-color", "rgb(" + (state < 1 ? "67,181,129" : (state > 1 ? "114,137,218" : "241,71,71")) + ")", state > 1 ? "" : "important");
 			themeRepoModal.entries[data.url] = data;
 		};


### PR DESCRIPTION
Makes more sense. I wouldn't know to click on a button that said 'Outdated', but I would know to click on one that says 'Update'